### PR TITLE
Added 'pfAjaxSuccess' event to fileUpload

### DIFF
--- a/primefaces/src/main/resources/META-INF/resources/primefaces/fileupload/2-fileupload.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/fileupload/2-fileupload.js
@@ -342,6 +342,10 @@ PrimeFaces.widget.FileUpload = PrimeFaces.widget.BaseWidget.extend({
                 $this.removeFiles(data.files);
 
                 PrimeFaces.ajax.Response.handle(data.result, data.textStatus, data.jqXHR, null);
+                
+                if($this.cfg.global) {
+                    $(document).trigger('pfAjaxSuccess');
+                }
             },
             always: function(e, data) {
                 if($this.cfg.oncomplete) {


### PR DESCRIPTION
This fixes issue #8126.

Ajax indicator now gets hidden when upload is done.